### PR TITLE
Implement basic multi-project orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,26 @@ tmux new-window -n mobile-pm
 # Orchestrator coordinates between PMs
 ```
 
+You can automate this setup with the `multi-project-orchestrator.sh` script. Define
+your projects in `config/projects.conf`:
+
+```bash
+frontend:/path/to/frontend/project
+backend:/path/to/backend/project
+```
+
+Then deploy all sessions at once:
+
+```bash
+./scripts/multi-project-orchestrator.sh deploy
+```
+
+Generate a combined status report anytime:
+
+```bash
+./scripts/multi-project-orchestrator.sh status
+```
+
 ### Cross-Project Intelligence
 The orchestrator can share insights between projects:
 - "Frontend is using /api/v2/users, update backend accordingly"
@@ -249,6 +269,8 @@ The orchestrator can share insights between projects:
 - `send-claude-message.sh` - Simplified agent communication script
 - `schedule_with_note.sh` - Self-scheduling functionality
 - `tmux_utils.py` - Tmux interaction utilities
+- `scripts/multi-project-orchestrator.sh` - Launch and monitor multiple projects
+- `scripts/multi_project_status.py` - Generate combined status reports
 - `CLAUDE.md` - Agent behavior instructions
 - `LEARNINGS.md` - Accumulated knowledge base
 

--- a/config/projects.conf
+++ b/config/projects.conf
@@ -1,0 +1,5 @@
+# session_name:path_to_project
+# Example entries
+frontend:/path/to/frontend/project
+backend:/path/to/backend/project
+mobile:/path/to/mobile/project

--- a/scripts/multi-project-orchestrator.sh
+++ b/scripts/multi-project-orchestrator.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Multi-Project Tmux Orchestrator
+# Simplified orchestration across multiple projects using tmux sessions
+# Usage: ./scripts/multi-project-orchestrator.sh [deploy|status] [config_file]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONFIG_FILE="${2:-${PROJECT_ROOT}/config/projects.conf}"
+LOG_DIR="${PROJECT_ROOT}/logs"
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log() {
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+log_status() {
+    echo -e "${GREEN}[STATUS]${NC} $1"
+}
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+check_dependencies() {
+    for cmd in tmux python3; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            log_error "$cmd not found. Please install it first."
+            exit 1
+        fi
+    done
+    mkdir -p "$LOG_DIR"
+}
+
+start_project_session() {
+    local session_name="$1"
+    local project_path="$2"
+
+    if tmux has-session -t "$session_name" 2>/dev/null; then
+        log_info "Session $session_name already exists"
+    else
+        tmux new-session -d -s "$session_name" -c "$project_path"
+        tmux rename-window -t "$session_name:0" "Manager"
+        tmux send-keys -t "$session_name:0" "claude" Enter
+        sleep 2
+        "$SCRIPT_DIR/../send-claude-message.sh" "$session_name:0" "You are the Project Manager for $session_name. Coordinate tasks and report status." || true
+        log_status "Started session $session_name at $project_path"
+    fi
+}
+
+deploy_projects() {
+    if [ ! -f "$CONFIG_FILE" ]; then
+        log_error "Config file not found: $CONFIG_FILE"
+        exit 1
+    fi
+    while IFS= read -r line; do
+        [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+        session="${line%%:*}"
+        path="${line#*:}"
+        start_project_session "$session" "$path"
+    done < "$CONFIG_FILE"
+}
+
+generate_status() {
+    local status_file="$LOG_DIR/multi-project-status-$(date +%Y%m%d-%H%M%S).md"
+    python3 - <<PY
+from tmux_utils import TmuxOrchestrator
+orchestrator = TmuxOrchestrator()
+print(orchestrator.create_monitoring_snapshot())
+PY
+    > "$status_file"
+    log_status "Status report generated: $status_file"
+}
+
+main() {
+    local cmd="${1:-deploy}"
+    check_dependencies
+    case "$cmd" in
+        deploy)
+            deploy_projects
+            ;;
+        status)
+            generate_status
+            ;;
+        *)
+            echo "Usage: $0 [deploy|status] [config_file]"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/multi_project_status.py
+++ b/scripts/multi_project_status.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Generate a combined tmux status report for all sessions."""
+
+import argparse
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tmux_utils import TmuxOrchestrator
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate multi-project status report")
+    parser.add_argument("-o", "--output", help="Write report to file")
+    args = parser.parse_args()
+
+    orchestrator = TmuxOrchestrator()
+    snapshot = orchestrator.create_monitoring_snapshot()
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(snapshot)
+        print(f"Status report written to {args.output}")
+    else:
+        print(snapshot)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `multi-project-orchestrator.sh` for launching multiple project sessions
- provide sample `projects.conf` for defining projects
- expose `multi_project_status.py` utility for combined status reports
- document multi-project workflow in README

## Testing
- `python3 scripts/multi_project_status.py --output /tmp/status.md` *(fails: FileNotFoundError: 'tmux')*

------
https://chatgpt.com/codex/tasks/task_b_68778bd89330832e996d0e8662b916eb